### PR TITLE
Add command to delete post meta

### DIFF
--- a/includes/meta/class-meta.php
+++ b/includes/meta/class-meta.php
@@ -9,6 +9,7 @@
 namespace Cata\CLI;
 
 use WP_CLI;
+use WP_CLI\Utils;
 use Exception;
 
 /**
@@ -68,6 +69,70 @@ class Meta {
 				)
 			);
 			WP_CLI::log( "Updated {$result} rows." );
+		} catch ( Exception $e ) {
+			WP_CLI::error( $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Delete post meta
+	 * 
+	 * <key>
+	 * : Post meta key
+	 * 
+	 * [--dry_run=<boolean>]
+	 * : Dry run.
+	 * ---
+	 * default: false
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 * 
+	 * @when after_wp_load
+	 */
+	public function delete_post_meta( array $args, array $assoc_args ) : void {
+		global $wpdb;
+
+		$assoc_args = wp_parse_args(
+			$assoc_args,
+			array(
+				'dry_run' => 'false',
+			)
+		);
+
+		$count = $wpdb->query(
+			$wpdb->prepare(
+				"SELECT * FROM `$wpdb->postmeta` WHERE meta_key = %s",
+				sanitize_key( $args[0] )
+			)
+		);
+
+		WP_CLI::log( "Found {$count} rows to delete." );
+
+		$examples = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM `$wpdb->postmeta` WHERE meta_key = %s LIMIT 10",
+				sanitize_key( $args[0] )
+			)
+		);
+
+		WP_CLI::log( "Here are the first 10 results for reference." );
+
+		WP_CLI\Utils\format_items( 'table', $examples, ['meta_id', 'post_id', 'meta_key', 'meta_value'] );
+
+		if ( self::is_dry_run( $assoc_args ) ) {
+			return;
+		}
+
+		try {
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM `$wpdb->postmeta` WHERE meta_key = %s",
+					sanitize_key( $args[0] )
+				)
+			);
+			WP_CLI::log( "Deleted {$result} rows." );
 		} catch ( Exception $e ) {
 			WP_CLI::error( $e->getMessage() );
 		}


### PR DESCRIPTION
### Related Issues
- Resolves #2 

### What Was Accomplished
- Added `wp cata delete_post_meta` command that accepts a post meta key as an unamed argument and `--dry_run=true|false` as a named argument.

### How It Was Tested
- Used `--dry_run=true` to mock deleting post meta like `_wp_attached_file`
- Deleted post meta like `_edit_last` and `_edit_lock` in a Local environment running WP `6.0.3-alpha-54512`