### PR TITLE
Provide post_type parameter for post_meta related commands

### DIFF
--- a/cata-cli.php
+++ b/cata-cli.php
@@ -12,7 +12,7 @@
  * Description: WP CLI Commands to support sites using cata parent theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.2.0
+ * Version:     0.2.1-beta1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/cata-cli.php
+++ b/cata-cli.php
@@ -12,7 +12,7 @@
  * Description: WP CLI Commands to support sites using cata parent theme.
  * Author:      Thought & Expression Co. <devjobs@thought.is>
  * Author URI:  https://thought.is
- * Version:     0.2.1-beta1
+ * Version:     0.2.1
  * License:     GPL v3 or later
  * License URI: http://www.gnu.org/licenses/gpl-3.0.txt
  */

--- a/includes/meta/class-meta.php
+++ b/includes/meta/class-meta.php
@@ -9,7 +9,6 @@
 namespace Cata\CLI;
 
 use WP_CLI;
-use WP_CLI\Utils;
 use Exception;
 
 /**
@@ -35,6 +34,12 @@ class Meta {
 	 *   - false
 	 * ---
 	 *
+	 * [--post_type=<string>]
+	 * : Specify post type to limit scope of deletion.
+	 * ---
+	 * default: 'any'
+	 * ---
+	 *
 	 * @when after_wp_load
 	 */
 	public function update_post_meta_key( array $args, array $assoc_args ) : void {
@@ -43,14 +48,25 @@ class Meta {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
-				'dry_run' => 'false',
+				'dry_run'   => 'false',
+				'post_type' => 'any',
 			)
 		);
 
+		$post_type = $assoc_args['post_type'];
+
+		if ( 'any' !== $post_type && ! post_type_exists( $post_type ) ) {
+			WP_CLI::log( "Post type {$post_type} not found, exiting." );
+			return;
+		}
+
+		$filter = $this->post_type_filter( $post_type );
+
 		$count = $wpdb->query(
 			$wpdb->prepare(
-				"SELECT * FROM `$wpdb->postmeta` WHERE meta_key = %s",
-				sanitize_key( $args[0] )
+				"SELECT meta_id FROM `$wpdb->postmeta` {$filter['join']} WHERE `$wpdb->postmeta`.`meta_key` = %s{$filter['where']}",
+				sanitize_key( $args[0] ),
+				...$filter['args']
 			)
 		);
 
@@ -63,11 +79,13 @@ class Meta {
 		try {
 			$result = $wpdb->query(
 				$wpdb->prepare(
-					"UPDATE `$wpdb->postmeta` SET meta_key = %s WHERE meta_key = %s",
+					"UPDATE `$wpdb->postmeta` {$filter['join']} SET `$wpdb->postmeta`.`meta_key` = %s WHERE `$wpdb->postmeta`.`meta_key` = %s{$filter['where']}",
 					sanitize_key( $args[1] ),
-					sanitize_key( $args[0] )
+					sanitize_key( $args[0] ),
+					...$filter['args']
 				)
 			);
+
 			WP_CLI::log( "Updated {$result} rows." );
 		} catch ( Exception $e ) {
 			WP_CLI::error( $e->getMessage() );
@@ -89,6 +107,12 @@ class Meta {
 	 *   - false
 	 * ---
 	 * 
+	 * [--post_type=<string>]
+	 * : Specify post type to limit scope of deletion.
+	 * ---
+	 * default: 'any'
+	 * ---
+	 * 
 	 * @when after_wp_load
 	 */
 	public function delete_post_meta( array $args, array $assoc_args ) : void {
@@ -97,39 +121,56 @@ class Meta {
 		$assoc_args = wp_parse_args(
 			$assoc_args,
 			array(
-				'dry_run' => 'false',
+				'dry_run'   => 'false',
+				'post_type' => 'any',
 			)
 		);
 
+		$post_type = $assoc_args['post_type'];
+
+		if ( 'any' !== $post_type && ! post_type_exists( $post_type ) ) {
+			WP_CLI::log( "Post type {$post_type} not found, exiting." );
+			return;
+		}
+
+		$filter = $this->post_type_filter( $post_type );
+
 		$count = $wpdb->query(
 			$wpdb->prepare(
-				"SELECT * FROM `$wpdb->postmeta` WHERE meta_key = %s",
-				sanitize_key( $args[0] )
+				"SELECT meta_id FROM `$wpdb->postmeta` {$filter['join']} WHERE `$wpdb->postmeta`.`meta_key` = %s{$filter['where']}",
+				sanitize_key( $args[0] ),
+				...$filter['args']
 			)
 		);
 
 		WP_CLI::log( "Found {$count} rows to delete." );
 
+		$select  = ( 'any' === $post_type ) ? '' : ", `$wpdb->posts`.`post_type`";
+		$columns = ( 'any' === $post_type )
+			? array( 'meta_id', 'post_id', 'meta_key', 'meta_value' )
+			: array( 'post_type', 'meta_id', 'post_id', 'meta_key', 'meta_value' );
+
 		$examples = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT * FROM `$wpdb->postmeta` WHERE meta_key = %s LIMIT 10",
-				sanitize_key( $args[0] )
+				"SELECT `$wpdb->postmeta`.`meta_id`, `$wpdb->postmeta`.`post_id`, `$wpdb->postmeta`.`meta_key`, `$wpdb->postmeta`.`meta_value`{$select} FROM `$wpdb->postmeta` {$filter['join']} WHERE `$wpdb->postmeta`.`meta_key` = %s{$filter['where']} LIMIT 10",
+				sanitize_key( $args[0] ),
+				...$filter['args']
 			)
 		);
 
 		WP_CLI::log( "Here are the first 10 results for reference." );
 
-		WP_CLI\Utils\format_items( 'table', $examples, ['meta_id', 'post_id', 'meta_key', 'meta_value'] );
+		WP_CLI\Utils\format_items( 'table', $examples, $columns );
 
 		if ( self::is_dry_run( $assoc_args ) ) {
 			return;
 		}
-
 		try {
 			$result = $wpdb->query(
 				$wpdb->prepare(
-					"DELETE FROM `$wpdb->postmeta` WHERE meta_key = %s",
-					sanitize_key( $args[0] )
+					"DELETE `$wpdb->postmeta` FROM `$wpdb->postmeta` {$filter['join']} WHERE `$wpdb->postmeta`.`meta_key` = %s{$filter['where']}",
+					sanitize_key( $args[0] ),
+					...$filter['args']
 				)
 			);
 			WP_CLI::log( "Deleted {$result} rows." );
@@ -139,8 +180,36 @@ class Meta {
 	}
 
 	/**
+	 * Build the post_type filter fragments for a postmeta query.
+	 *
+	 * Returns the JOIN clause, the trailing WHERE condition, and any extra
+	 * prepare() arguments needed to scope a query to a single post type.
+	 * For 'any' the fragments are empty, leaving the base query unfiltered.
+	 *
+	 * @param string $post_type Post type slug, or 'any' for no filter.
+	 * @return array{join:string, where:string, args:array}
+	 */
+	private function post_type_filter( string $post_type ) : array {
+		global $wpdb;
+
+		if ( 'any' === $post_type ) {
+			return array(
+				'join'  => '',
+				'where' => '',
+				'args'  => array(),
+			);
+		}
+
+		return array(
+			'join'  => "JOIN `$wpdb->posts` ON `$wpdb->posts`.`ID` = `$wpdb->postmeta`.`post_id`",
+			'where' => " AND `$wpdb->posts`.`post_type` = %s",
+			'args'  => array( sanitize_key( $post_type ) ),
+		);
+	}
+
+	/**
 	 * Is Dry Run
-	 * 
+	 *
 	 * @param array $assoc_args
 	 * @return bool
 	 */


### PR DESCRIPTION
### Related Issues

- Resolves #4 

### What Was Accomplished

- Added `post_type` parameter
  - Applied to `update_post_meta_key` and `delete_post_meta` commands
  - The default is `any`. When the value is `any` no adjustments are made the the SQL query and all post types will be affected by this command.
  - If a value is provided for post_type it must pass `post_type_exists` before executing the rest of the command.